### PR TITLE
feat: use codecov instead of coverall

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
@@ -24,12 +26,17 @@ jobs:
           gpg-passphrase: GPG_PASSPHRASE
 
       - name: Build with Maven
-        run: mvn clean test
+        run: mvn clean test cobertura:cobertura
 
       - name: Codecov
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
 
       - name: Sematic Release
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -175,11 +175,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.eluder.coveralls</groupId>
-                <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.3.0</version>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
                 <version>2.7</version>


### PR DESCRIPTION
Add cobertura command and remove coverall, and test semantic-release.

Fix: https://github.com/jcasbin/redis-watcher/issues/16